### PR TITLE
Binning algorithm change

### DIFF
--- a/illustris_frb/illustris_frb.py
+++ b/illustris_frb/illustris_frb.py
@@ -63,7 +63,7 @@ class simulation:
         with h5py.File(header_file) as f:
             self.header = dict(f['Header'].attrs)
 
-        self.boxsize = int(self.header['BoxSize'])
+        self.boxsize = self.header['BoxSize']
         self.binsize = binsize
         self.n_bins = int(self.boxsize / self.binsize)
         

--- a/scripts/create_n_e_map.py
+++ b/scripts/create_n_e_map.py
@@ -27,7 +27,7 @@ full_snaps = (2, 3, 4, 6, 8, 11, 13, 17, 21, 25, 33, 40, 50, 59, 67, 72, 78, 84,
 def sort_chunks_to_bins(sim, snap):
     
     full_snap = snap in full_snaps
-    res = np.zeros(sim.n_bins**3)
+    res = np.zeros(sim.n_bins**3, dtype=np.float64)
     
     for chunk in range(len(os.listdir(sim.get_snapdir_path(snap)))):
 
@@ -40,8 +40,9 @@ def sort_chunks_to_bins(sim, snap):
             coords = np.array(f['PartType0/Coordinates'])
 
             #calculate electron number count; N_e = m_g eta_e X_H / m_p
-
-            m_g = (np.array(f['PartType0/Masses'], dtype=np.float64) * 1e10 * u.solMass / cu.littleh).to(u.kg, sim.h_equiv)
+            m_g = (np.array(f['PartType0/Masses'], dtype=np.float64) * 1e10 * u.solMass / cu.littleh)
+            simH0 = 100 * u.km/u.s/u.Mpc * sim.h
+            m_g = m_g.to(u.kg, cu.with_H0(simH0))
             eta_e = np.array(f['PartType0/ElectronAbundance'])
 
             #X_H only given in full snaps
@@ -62,8 +63,8 @@ def sort_chunks_to_bins(sim, snap):
         
         # mem = process.memory_info().rss/1024**3
         # print(f'{time.time()-start_time:<6.2f}: Done with chunk {chunk}. Current memory: {mem:.1f} GB')
-
-    np.save(os.path.join(sim.map_dir, f'{snap}.npy'), res)
+    print(sim.emap_dir)
+    np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res)
 
 
 #set argparse
@@ -73,10 +74,10 @@ argp.add_argument("-s", "--sim", type=str, required=True, choices=os.listdir('/h
 argp.add_argument("--binsize", type=int, default=500, help="The size of a bin in ckpc/h. Default=500")
 argp.add_argument("--snaps", type=int, default=[99], nargs='+', help="Which snapshots to process. Default=99")
 argp.add_argument("--snap-range", type=int, nargs=2, help="Range of snapshots to process, inclusive. Ignores --snaps if specified. ")
-argp.add_argument("--outpath", type=str, default=None, help="Path to where the output electron density map will go. If unspecified, will go to ./n_e_maps/{sim}")
+argp.add_argument("--outpath", type=str, default='./n_e_maps', help="Path to where the output electron density map will go. If unspecified, will go to ./n_e_maps/{sim}")
 args = argp.parse_args()
 
-sim = simulation(args.sim, args.binsize, map_dir=args.outpath)
+sim = simulation(args.sim, args.binsize, emap_dir=args.outpath)
 
 if args.snap_range is None:
     snaps_list = args.snaps
@@ -88,7 +89,7 @@ else:
         snaps_list = range(a, b+1)
 
 #run
-print(f'{n_bins}^3 = {n_bins**3} bins of size {binsize} ckpc/h')
+print(f'{sim.n_bins}^3 = {sim.n_bins**3} bins of size {sim.binsize} ckpc/h')
 
 start_time = time.time()
 for snap in snaps_list:

--- a/scripts/create_n_e_map.py
+++ b/scripts/create_n_e_map.py
@@ -36,8 +36,13 @@ def sort_chunks_to_bins(sim, snap, density):
         dtype = np.float64
         pixel_volume = 1.
     res = np.zeros(sim.n_bins**3, dtype=dtype)
-    
-    n_bins_padded = sim.n_bins + 1
+
+    if sim.boxsize % sim.binsize < 1e-5 * sim.binsize:
+        whole_binning = True
+        n_bins_padded = sim.n_bins
+    else:
+        n_bins_padded = sim.n_bins + 1
+
     res = np.zeros((n_bins_padded,) * 3, dtype=dtype)
     res_flat = res.reshape(-1)
     
@@ -68,21 +73,26 @@ def sort_chunks_to_bins(sim, snap, density):
         N_e = m_g * eta_e * X_H / (const.m_p * pixel_volume)
         N_e = N_e.astype(dtype)
 
-        # mod by boxsize seems to be nessisary, since for some reason, 0 < coords <= boxsize.
-        bin_index = ((coords[:,0] % sim.boxsize) // sim.binsize)*n_bins_padded**2 + \
-                    ((coords[:,1] % sim.boxsize) // sim.binsize)*n_bins_padded + \
-                    ((coords[:,2] % sim.boxsize) // sim.binsize)
-        bin_index = bin_index.astype(int)
+        if whole_binning:
+            bin_index = ((coords / sim.boxsize) * n_bins_padded).astype(int) % n_bins_padded
+            bin_index = bin_index[:,0] * n_bins_padded**2 + \
+                        bin_index[:,1] * n_bins_padded + \
+                        bin_index[:,2]
+        else:
+            # mod by boxsize seems to be nessisary, since for some reason, 0 < coords <= boxsize.
+            bin_index = ((coords[:,0] % sim.boxsize) // sim.binsize)*n_bins_padded**2 + \
+                        ((coords[:,1] % sim.boxsize) // sim.binsize)*n_bins_padded + \
+                        ((coords[:,2] % sim.boxsize) // sim.binsize)
+            bin_index = bin_index.astype(int)
 
         np.add.at(res_flat, bin_index, N_e.value)
         
         # mem = process.memory_info().rss/1024**3
         # print(f'{time.time()-start_time:<6.2f}: Done with chunk {chunk}. Current memory: {mem:.1f} GB')
     
-    # Saving the sliced array without flattening prevents a full copy, saving a factor of 2 in memory.
-    np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res[:-1,:-1,:-1])
-    #res_flat = res[:-1,:-1,:-1].reshape(-1)
-    #np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res_flat)
+    # Note that the .flatten() costs a factor of 2 in memory when using the padded binning
+    # and the slices is nontrivial.
+    np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res[:sim.n_bins,:sim.n_bins,:sim.n_bins].flatten())
 
 
 
@@ -95,9 +105,13 @@ argp.add_argument("--snaps", type=int, default=[99], nargs='+', help="Which snap
 argp.add_argument("--snap-range", type=int, nargs=2, help="Range of snapshots to process, inclusive. Ignores --snaps if specified. ")
 argp.add_argument("--outpath", type=str, default='./n_e_maps', help="Path to where the output electron density map will go. If unspecified, will go to ./n_e_maps/{sim}")
 argp.add_argument("--density", action='store_true', default=False, help="Make map in density units of cm^-3 instead of electron number counts. Incompatible with ray tracing code, but more efficient due to reduced memory overflows.")
+argp.add_argument("--round-binsize", action='store_true', default=False, help="Round the binsize to evenly divide the boxsize.")
 args = argp.parse_args()
 
 sim = simulation(args.sim, args.binsize, emap_dir=args.outpath)
+if args.round_binsize:
+    if sim.boxsize % sim.binsize:
+        sim = simulation(args.sim, sim.boxsize / sim.n_bins, emap_dir=args.outpath)
 
 if args.snap_range is None:
     snaps_list = args.snaps

--- a/scripts/create_n_e_map.py
+++ b/scripts/create_n_e_map.py
@@ -68,9 +68,10 @@ def sort_chunks_to_bins(sim, snap, density):
         N_e = m_g * eta_e * X_H / (const.m_p * pixel_volume)
         N_e = N_e.astype(dtype)
 
-        bin_index = (coords[:,0] // sim.binsize)*n_bins_padded**2 + \
-                    (coords[:,1] // sim.binsize)*n_bins_padded + \
-                    (coords[:,2]  // sim.binsize)
+        # mod by boxsize seems to be nessisary, since for some reason, 0 < coords <= boxsize.
+        bin_index = ((coords[:,0] % sim.boxsize) // sim.binsize)*n_bins_padded**2 + \
+                    ((coords[:,1] % sim.boxsize) // sim.binsize)*n_bins_padded + \
+                    ((coords[:,2] % sim.boxsize) // sim.binsize)
         bin_index = bin_index.astype(int)
 
         np.add.at(res_flat, bin_index, N_e.value)

--- a/scripts/create_n_e_map.py
+++ b/scripts/create_n_e_map.py
@@ -24,24 +24,38 @@ given in the bottom of this file.
 
 full_snaps = (2, 3, 4, 6, 8, 11, 13, 17, 21, 25, 33, 40, 50, 59, 67, 72, 78, 84, 91, 99)
 
-def sort_chunks_to_bins(sim, snap):
-    
+def sort_chunks_to_bins(sim, snap, density):
+
     full_snap = snap in full_snaps
-    res = np.zeros(sim.n_bins**3, dtype=np.float64)
+
+    simH0 = 100 * u.km/u.s/u.Mpc * sim.h
+    if density:
+        dtype = np.float32
+        pixel_volume = ((sim.binsize * u.kpc / cu.littleh)**3).to(u.cm**3, cu.with_H0(simH0))
+    else:
+        dtype = np.float64
+        pixel_volume = 1.
+    res = np.zeros(sim.n_bins**3, dtype=dtype)
     
-    for chunk in range(len(os.listdir(sim.get_snapdir_path(snap)))):
+    n_bins_padded = sim.n_bins + 1
+    res = np.zeros((n_bins_padded,) * 3, dtype=dtype)
+    res_flat = res.reshape(-1)
+    
+    nchunks = len(os.listdir(sim.get_snapdir_path(snap)))
+    for chunk in range(nchunks):
 
         #process and save the electron number counts + coordinates of all particles
 
         chunk_path = sim.get_snap_chunk_path(snap, chunk)
-
+        
+        print(f"Snapshot {snap}, chunk {chunk} of {nchunks}")
         with h5py.File(chunk_path) as f:
 
             coords = np.array(f['PartType0/Coordinates'])
+            print(coords.shape, np.max(coords, 0), np.min(coords, 0))
 
             #calculate electron number count; N_e = m_g eta_e X_H / m_p
             m_g = (np.array(f['PartType0/Masses'], dtype=np.float64) * 1e10 * u.solMass / cu.littleh)
-            simH0 = 100 * u.km/u.s/u.Mpc * sim.h
             m_g = m_g.to(u.kg, cu.with_H0(simH0))
             eta_e = np.array(f['PartType0/ElectronAbundance'])
 
@@ -52,29 +66,32 @@ def sort_chunks_to_bins(sim, snap):
             else:
                 X_H = (1-np.array(f['PartType0/GFM_Metallicity']))*0.76
 
-        N_e = m_g * eta_e * X_H / const.m_p
+        N_e = m_g * eta_e * X_H / (const.m_p * pixel_volume)
+        N_e = N_e.astype(dtype)
 
-        bin_index = (coords[:,0] // sim.binsize)*sim.n_bins**2 + \
-                    (coords[:,1] // sim.binsize)*sim.n_bins + \
+        bin_index = (coords[:,0] // sim.binsize)*n_bins_padded**2 + \
+                    (coords[:,1] // sim.binsize)*n_bins_padded + \
                     (coords[:,2]  // sim.binsize)
+        bin_index = bin_index.astype(int)
 
-        res += pd.DataFrame({'i': bin_index, 'N_e': N_e}).groupby(by='i').sum().reindex(range(sim.n_bins**3), fill_value=0).to_numpy()[:,0]
-        #creates a {n_bins}^3 long array. each slot has N_e for each corresponding bin
+        np.add.at(res_flat, bin_index, N_e.value)
         
         # mem = process.memory_info().rss/1024**3
         # print(f'{time.time()-start_time:<6.2f}: Done with chunk {chunk}. Current memory: {mem:.1f} GB')
-    print(sim.emap_dir)
+    res = res[:-1,:-1,:-1].reshape(-1)
     np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res)
+
 
 
 #set argparse
 argp = argparse.ArgumentParser()
 argp.add_argument("-s", "--sim", type=str, required=True, choices=os.listdir('/home/tnguser/sims.TNG'), 
                   help="Name of simulation as given in the path, e.g. L205n2500TNG")
-argp.add_argument("--binsize", type=int, default=500, help="The size of a bin in ckpc/h. Default=500")
+argp.add_argument("--binsize", type=float, default=500, help="The size of a bin in ckpc/h. Default=500")
 argp.add_argument("--snaps", type=int, default=[99], nargs='+', help="Which snapshots to process. Default=99")
 argp.add_argument("--snap-range", type=int, nargs=2, help="Range of snapshots to process, inclusive. Ignores --snaps if specified. ")
 argp.add_argument("--outpath", type=str, default='./n_e_maps', help="Path to where the output electron density map will go. If unspecified, will go to ./n_e_maps/{sim}")
+argp.add_argument("--density", action='store_true', default=False, help="Make map in density units of cm^-3 instead of electron number counts. Incompatible with ray tracing code, but more efficient due to reduced memory overflows.")
 args = argp.parse_args()
 
 sim = simulation(args.sim, args.binsize, emap_dir=args.outpath)
@@ -93,7 +110,7 @@ print(f'{sim.n_bins}^3 = {sim.n_bins**3} bins of size {sim.binsize} ckpc/h')
 
 start_time = time.time()
 for snap in snaps_list:
-    sort_chunks_to_bins(sim, snap)
+    sort_chunks_to_bins(sim, snap, args.density)
     print(f'{time.time()-start_time:<6.2f}: Done processing snapshot {snap}')
 
 

--- a/scripts/create_n_e_map.py
+++ b/scripts/create_n_e_map.py
@@ -36,11 +36,12 @@ def sort_chunks_to_bins(sim, snap, density):
         dtype = np.float64
         pixel_volume = 1.
     res = np.zeros(sim.n_bins**3, dtype=dtype)
-
-    if sim.boxsize % sim.binsize < 1e-5 * sim.binsize:
+    
+    if abs((sim.boxsize / sim.binsize + 0.5) % 1 - 0.5) < 1e-5:
         whole_binning = True
         n_bins_padded = sim.n_bins
     else:
+        whole_binning = False
         n_bins_padded = sim.n_bins + 1
 
     res = np.zeros((n_bins_padded,) * 3, dtype=dtype)
@@ -90,9 +91,9 @@ def sort_chunks_to_bins(sim, snap, density):
         # mem = process.memory_info().rss/1024**3
         # print(f'{time.time()-start_time:<6.2f}: Done with chunk {chunk}. Current memory: {mem:.1f} GB')
     
-    # Note that the .flatten() costs a factor of 2 in memory when using the padded binning
+    # Note that the reshape costs a factor of 2 in memory when using the padded binning
     # and the slices is nontrivial.
-    np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res[:sim.n_bins,:sim.n_bins,:sim.n_bins].flatten())
+    np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res[:sim.n_bins,:sim.n_bins,:sim.n_bins].reshape(-1))
 
 
 

--- a/scripts/create_n_e_map.py
+++ b/scripts/create_n_e_map.py
@@ -77,8 +77,11 @@ def sort_chunks_to_bins(sim, snap, density):
         
         # mem = process.memory_info().rss/1024**3
         # print(f'{time.time()-start_time:<6.2f}: Done with chunk {chunk}. Current memory: {mem:.1f} GB')
-    res = res[:-1,:-1,:-1].reshape(-1)
-    np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res)
+    
+    # Saving the sliced array without flattening prevents a full copy, saving a factor of 2 in memory.
+    np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res[:-1,:-1,:-1])
+    #res_flat = res[:-1,:-1,:-1].reshape(-1)
+    #np.save(os.path.join(sim.emap_dir, f'{snap}.npy'), res_flat)
 
 
 

--- a/scripts/create_n_e_map.py
+++ b/scripts/create_n_e_map.py
@@ -52,7 +52,6 @@ def sort_chunks_to_bins(sim, snap, density):
         with h5py.File(chunk_path) as f:
 
             coords = np.array(f['PartType0/Coordinates'])
-            print(coords.shape, np.max(coords, 0), np.min(coords, 0))
 
             #calculate electron number count; N_e = m_g eta_e X_H / m_p
             m_g = (np.array(f['PartType0/Masses'], dtype=np.float64) * 1e10 * u.solMass / cu.littleh)


### PR DESCRIPTION
This PR includes a handful of changes (sorry for not splitting them), but the biggest is a change to the binning algorithm, centered on `np.add.at` instead of pandas.  The new algorithm fixes a subtle bug, but is also much faster and more memory efficient.

The but occurs due to lines:
 
    bin_index = (coords[:,0] // sim.binsize)*sim.n_bins**2 + \
                    (coords[:,1] // sim.binsize)*sim.n_bins + \
                    (coords[:,2]  // sim.binsize)

When calculating the number of bins, the code rounds down from `boxsize / binsize`. As such `coords[:,0] // sim.binsize` can can exceed `n_bins - 1`, putting the particle in the wrong location. This happens even if `boxsize % binsize = 0` since the values of `coords`  can saturate the box size.

The other major change is to make a mode where the final produce is number density (in cm^-3) instead of the number of electrons. The latter can exceed 10^70, which annoyingly saturates 32 bit integers, doubling the memory cost.  The conversion factor is just the `binsize^3`.
