### PR TITLE
Fix (1+z) error in good-region size criterion

### DIFF
--- a/notebooks/get_good_pixels.ipynb
+++ b/notebooks/get_good_pixels.ipynb
@@ -258,24 +258,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "18d6e238-d856-44cd-92f2-05364465f905",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def get_d(v, s=sim.boxsize): # distance to nearest sightline image\n",
-    "    vhat = np.abs(v)/np.atleast_2d(norm(np.atleast_2d(v), axis=1)).T\n",
-    "    dists = []\n",
-    "    for check in np.mgrid[0:2, 0:2, 0:2].T.reshape(8,3)[1:]:\n",
-    "        dists.append(norm(np.atleast_2d(np.cross(vhat, check)), axis=1))\n",
-    "    res = s*np.amin(np.vstack(dists), axis=0)\n",
-    "    if v.ndim < 2:\n",
-    "        return res[0]\n",
-    "    return res\n",
-    "\n",
-    "def get_max_regsize(v, z):\n",
-    "    return get_d(v) / ( sim.cosmo.angular_diameter_distance(z).to(u.kpc).value * sim.h )"
-   ]
+   "source": "def get_d(v, s=sim.boxsize): # distance to nearest sightline image\n    vhat = np.abs(v)/np.atleast_2d(norm(np.atleast_2d(v), axis=1)).T\n    dists = []\n    for check in np.mgrid[0:2, 0:2, 0:2].T.reshape(8,3)[1:]:\n        dists.append(norm(np.atleast_2d(np.cross(vhat, check)), axis=1))\n    res = s*np.amin(np.vstack(dists), axis=0)\n    if v.ndim < 2:\n        return res[0]\n    return res\n\ndef get_max_regsize(v, z):\n    # get_d returns a COMOVING separation (boxsize is comoving), so it must be\n    # divided by the comoving distance -- NOT the proper angular-diameter distance.\n    # Since D_A = comoving_distance / (1+z), dividing by D_A overestimated the max\n    # allowed region size by a factor (1+z) (~1.4x at z=0.4, ~1.8x at z=0.8).\n    return get_d(v) / sim.comoving_distance(z)"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
get_max_regsize divided the comoving sightline-image separation (get_d, comoving since boxsize is comoving) by the *proper* angular-diameter distance D_A. Because D_A = comoving_distance / (1+z), this overestimated the maximum allowed sky-region size by a factor (1+z), making the constraint-2 good-region selection too permissive (~1.4x at z=0.4, ~1.8x at z=0.8). Divide by the comoving distance instead.